### PR TITLE
Develop

### DIFF
--- a/MailBlaster/app/Http/Controllers/TrixUploadController.php
+++ b/MailBlaster/app/Http/Controllers/TrixUploadController.php
@@ -9,11 +9,13 @@ class TrixUploadController extends Controller
     public function store(Request $request)
     {
         if ($request->hasFile('attachment')) {
-            $path = $request->file('attachment')->store('trix_images', 'public');
+            $folder = $request->input('folder', 'trix_images'); // Por defecto plantillas
+            $path = $request->file('attachment')->store($folder, 'public');
             return [
                 'success' => 1,
                 'file' => [
-                    'url' => asset('storage/' . $path)
+                    'url' => asset('storage/' . $path),
+                    'path' => $path
                 ]
             ];
         }

--- a/MailBlaster/resources/views/campaigns/partials/form.blade.php
+++ b/MailBlaster/resources/views/campaigns/partials/form.blade.php
@@ -50,6 +50,7 @@ document.getElementById('image-upload').addEventListener('change', function(e) {
     if (!file) return;
     const form = new FormData();
     form.append('attachment', file);
+    form.append('folder', 'campaign_images'); // Indica que es para campañas
 
     fetch("{{ route('trix.upload') }}", {
         method: "POST",


### PR DESCRIPTION
This pull request introduces enhancements to the file upload functionality in `TrixUploadController` and updates a related view to support dynamic folder selection for uploads. The changes improve flexibility by allowing different upload destinations based on context.

### Backend Changes:
* [`MailBlaster/app/Http/Controllers/TrixUploadController.php`](diffhunk://#diff-ac8b7e029c9828a9242e001860c47819f28b2654edc8050b157652e5cd337985L12-R18): Modified the `store` method to accept a `folder` input parameter, defaulting to `'trix_images'`, enabling dynamic folder selection for uploaded files. Additionally, the response now includes the file's storage path alongside its URL.

### Frontend Changes:
* [`MailBlaster/resources/views/campaigns/partials/form.blade.php`](diffhunk://#diff-bf827b0d50ae179e7062a8bf3c64f5aa7c355e62d191b1f5478a837843cc277aR53): Updated the form submission logic to append a `folder` parameter with the value `'campaign_images'` when uploading campaign-related files, ensuring they are stored in the appropriate directory.